### PR TITLE
Revert 'add text justification to markdown layout'

### DIFF
--- a/src/layouts/markdown-layout.astro
+++ b/src/layouts/markdown-layout.astro
@@ -7,7 +7,7 @@ const { frontmatter } = Astro.props;
 ---
 
 <StandardNavbarLayout>
-    <section class="md flex flex-col gap-12 items-center text-justify" style="text-align: justify;">
+    <section class="md flex flex-col gap-12 items-center text-left">
         <slot />
     </section>
 </StandardNavbarLayout>


### PR DESCRIPTION
Pozeral som si vysledok tejto zmeny na mobile a s niekolkymi ludmi som sa zhodol ze sa to tazko citalo a left-aligned to bolo lepsie.

Podme diskutovat!